### PR TITLE
feat: make the callback url setable by the user before the middleware hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # UNRELEASED CHANGES:
 
  ### New features:
-  *
+  * Make the callback url setable by the user before the middleware hit
 
  ### Enhancements:
   *

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Route::middleware(['auth', 'webauthn'])->group(function () {
 }
 ```
 
-This way user would have to validates their key on login.
+This way users would have to validate their key on login.
 
 
 ## Authenticate
@@ -100,7 +100,7 @@ The `webauthn.authenticate.postSuccessCallback` configuration is used to redirec
 If the value is false, the `webauthn.authenticate.postSuccessRedirectRoute` is used as a redirect route.
 
 If `postSuccessCallback` is false and `postSuccessRedirectRoute` is empty, the return will be JSON form:
-```json
+```javascript
 {
     result: true,
     callback: 'http://localhost',
@@ -145,13 +145,13 @@ The default value will open [webauthn::register](/resources/views/register.blade
 The `webauthn.register.postSuccessRedirectRoute` configuration is used to redirect the submit form after the registration.
 
 If `postSuccessRedirectRoute` is empty, the return will be JSON form:
-```json
+```javascript
 {
     result: true,
     id: 42,
-    object => 'webauthnKey',
-    name => 'name of the key',
-    counter => 12,
+    object: 'webauthnKey',
+    name: 'name of the key',
+    counter: 12,
 }
 ```
 

--- a/src/Http/Middleware/WebauthnMiddleware.php
+++ b/src/Http/Middleware/WebauthnMiddleware.php
@@ -28,6 +28,7 @@ class WebauthnMiddleware
      * Create a Webauthn.
      *
      * @param \Illuminate\Contracts\Config\Repository $config
+     * @param \Illuminate\Contracts\Auth\Factory $auth
      */
     public function __construct(Config $config, AuthFactory $auth)
     {
@@ -50,7 +51,12 @@ class WebauthnMiddleware
             abort_if($this->auth->guard($guard)->guest(), 401, trans('webauthn::errors.user_unauthenticated'));
 
             if (Webauthn::enabled($request->user($guard))) {
-                return Redirect::guest(route('webauthn.login'));
+
+                if ($request->session()->has('url.intended')) {
+                    return Redirect::to(route('webauthn.login'));
+                } else {
+                    return Redirect::guest(route('webauthn.login'));
+                }
             }
         }
 

--- a/src/Http/Middleware/WebauthnMiddleware.php
+++ b/src/Http/Middleware/WebauthnMiddleware.php
@@ -51,7 +51,7 @@ class WebauthnMiddleware
             abort_if($this->auth->guard($guard)->guest(), 401, trans('webauthn::errors.user_unauthenticated'));
 
             if (Webauthn::enabled($request->user($guard))) {
-                if ($request->session()->has('url.intended')) {
+                if ($request->hasSession() && $request->session()->has('url.intended')) {
                     return Redirect::to(route('webauthn.login'));
                 } else {
                     return Redirect::guest(route('webauthn.login'));

--- a/src/Http/Middleware/WebauthnMiddleware.php
+++ b/src/Http/Middleware/WebauthnMiddleware.php
@@ -51,7 +51,6 @@ class WebauthnMiddleware
             abort_if($this->auth->guard($guard)->guest(), 401, trans('webauthn::errors.user_unauthenticated'));
 
             if (Webauthn::enabled($request->user($guard))) {
-
                 if ($request->session()->has('url.intended')) {
                     return Redirect::to(route('webauthn.login'));
                 } else {


### PR DESCRIPTION
You can now set the intented url before the webauthn middleware like
```php
Redirect::setIntendedUrl(route('myroute'));
```