### PR TITLE
fix: securing the register route from unchecked users

### DIFF
--- a/resources/lang/de/errors.php
+++ b/resources/lang/de/errors.php
@@ -4,6 +4,7 @@ return [
     'user_unauthenticated' => 'Sie müssen sich vor einer WebAuthn-Authentifizierung anmelden',
     'auth_data_not_found' => 'Authentifizierungsdaten nicht gefunden',
     'create_data_not_found' => 'Registrierungsdaten nicht gefunden',
+    'cannot_register_new_key' => 'Sie müssen sich anmelden, bevor Sie eine neue Webauthn-Authentifizierung hinzufügen',
     'object_not_found' => 'Objekt nicht gefunden',
 
     'not_supported' => 'Ihr Browser unterstützt noch kein WebAuthn.',

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -4,6 +4,7 @@ return [
     'user_unauthenticated' => 'You need to log in before doing a Webauthn authentication',
     'auth_data_not_found' => 'Authentication data not found',
     'create_data_not_found' => 'Register data not found',
+    'cannot_register_new_key' => 'You need to log in before adding a new Webauthn authentication',
     'object_not_found' => 'Object not found',
 
     'not_supported' => 'Your browser doesn’t currently support WebAuthn.',

--- a/resources/lang/fr/errors.php
+++ b/resources/lang/fr/errors.php
@@ -4,6 +4,7 @@ return [
     'user_unauthenticated' => 'Vous devez vous connecter avant de faire une authentification Webauthn',
     'auth_data_not_found' => 'Données d’authentification introuvables',
     'create_data_not_found' => 'Données d’enregistrement non trouvées',
+    'cannot_register_new_key' => 'Vous devez vous connecter avant de pouvoir ajouter une nouvelle authentification Webauthn',
     'object_not_found' => 'Objet introuvable',
 
     'not_supported' => 'Votre navigateur ne prend actuellement pas en charge WebAuthn.',

--- a/src/Facades/Webauthn.php
+++ b/src/Facades/Webauthn.php
@@ -14,6 +14,7 @@ use Webauthn\PublicKeyCredentialRequestOptions;
  * @method static void forceAuthenticate()
  * @method static bool check()
  * @method static bool enabled(\Illuminate\Contracts\Auth\Authenticatable $user)
+ * @method static bool canRegister(\Illuminate\Contracts\Auth\Authenticatable $user)
  *
  * @see \LaravelWebauthn\Webauthn
  */

--- a/src/Http/Controllers/WebauthnController.php
+++ b/src/Http/Controllers/WebauthnController.php
@@ -135,7 +135,7 @@ class WebauthnController extends Controller
      */
     public function register(Request $request)
     {
-        if(!Webauthn::canRegister($request->user())) {
+        if (! Webauthn::canRegister($request->user())) {
             return Response::json([
                 'error' => [
                     'message' => trans('webauthn::errors.cannot_register_new_key'),
@@ -178,7 +178,7 @@ class WebauthnController extends Controller
      */
     public function create(Request $request)
     {
-        if(!Webauthn::canRegister($request->user())) {
+        if (! Webauthn::canRegister($request->user())) {
             return Response::json([
                 'error' => [
                     'message' => trans('webauthn::errors.cannot_register_new_key'),

--- a/src/Http/Controllers/WebauthnController.php
+++ b/src/Http/Controllers/WebauthnController.php
@@ -135,6 +135,14 @@ class WebauthnController extends Controller
      */
     public function register(Request $request)
     {
+        if(!Webauthn::canRegister($request->user())) {
+            return Response::json([
+                'error' => [
+                    'message' => trans('webauthn::errors.cannot_register_new_key'),
+                ],
+            ], 403);
+        }
+
         $publicKey = Webauthn::getRegisterData($request->user());
 
         $request->session()->put(self::SESSION_PUBLICKEY_CREATION, $publicKey);
@@ -170,6 +178,14 @@ class WebauthnController extends Controller
      */
     public function create(Request $request)
     {
+        if(!Webauthn::canRegister($request->user())) {
+            return Response::json([
+                'error' => [
+                    'message' => trans('webauthn::errors.cannot_register_new_key'),
+                ],
+            ], 403);
+        }
+
         try {
             $publicKey = $request->session()->pull(self::SESSION_PUBLICKEY_CREATION);
             if (! $publicKey instanceof PublicKeyCredentialCreationOptions) {

--- a/src/Services/Webauthn.php
+++ b/src/Services/Webauthn.php
@@ -182,6 +182,6 @@ class Webauthn extends WebauthnRepository
      */
     public function canRegister(User $user): bool
     {
-        return (bool) ! $this->enabled($user) || $this->check();
+        return ! $this->enabled($user) || $this->check();
     }
 }

--- a/src/Services/Webauthn.php
+++ b/src/Services/Webauthn.php
@@ -173,4 +173,15 @@ class Webauthn extends WebauthnRepository
     {
         return (bool) $this->config->get('webauthn.enable', true) && $this->hasKey($user);
     }
+
+    /**
+     * Test if the user can register a new token.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return bool
+     */
+    public function canRegister(User $user): bool
+    {
+        return (bool) ! $this->enabled($user) || $this->check();
+    }
 }

--- a/tests/Fake/FakeWebauthn.php
+++ b/tests/Fake/FakeWebauthn.php
@@ -86,4 +86,9 @@ class FakeWebauthn
         return $this->app['config']->get('webauthn.enable') &&
             WebauthnKey::where('user_id', $user->getAuthIdentifier())->count() > 0;
     }
+
+    public function canRegister(User $user): bool
+    {
+        return (bool) ! $this->enabled($user) || $this->check();
+    }
 }

--- a/tests/Unit/WebauthnControllerTest.php
+++ b/tests/Unit/WebauthnControllerTest.php
@@ -115,6 +115,37 @@ class WebauthnControllerTest extends FeatureTestCase
         ]);
     }
 
+    public function test_register_view_without_check()
+    {
+        config(['webauthn.register.view' => '']);
+        $user = $this->signIn();
+        $webauthnKey = factory(WebauthnKey::class)->create([
+            'user_id' => $user->getAuthIdentifier(),
+        ]);
+
+        $response = $this->get('/webauthn/register');
+        $response->assertStatus(403);
+    }
+
+    public function test_register_create_without_check()
+    {
+        config(['webauthn.register.postSuccessRedirectRoute' => '']);
+
+        $user = $this->signIn();
+        $webauthnKey = factory(WebauthnKey::class)->create([
+            'user_id' => $user->getAuthIdentifier(),
+        ]);
+
+        $this->session(['webauthn.publicKeyCreation' => Webauthn::getRegisterData($user)]);
+
+        $response = $this->post('/webauthn/register', [
+            'register' => '',
+            'name' => 'keyname',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
     public function test_register_create()
     {
         config(['webauthn.register.postSuccessRedirectRoute' => '']);


### PR DESCRIPTION
This PR is related to issue #314
I think that will prevent un-authenticated user to bypass check by registering a new FIDO / 2FA token into the user account