### PR TITLE
Use host without port for RP ID

### DIFF
--- a/src/Services/Webauthn/PublicKeyCredentialCreationOptionsFactory.php
+++ b/src/Services/Webauthn/PublicKeyCredentialCreationOptionsFactory.php
@@ -54,7 +54,7 @@ final class PublicKeyCredentialCreationOptionsFactory extends AbstractOptionsFac
     {
         return new PublicKeyCredentialRpEntity(
             $this->config->get('app.name', 'Laravel'),
-            Request::getHttpHost(),
+            Request::getHost(),
             $this->config->get('webauthn.icon')
         );
     }


### PR DESCRIPTION
"The origin's port is unrestricted"
https://www.w3.org/TR/webauthn-2/#rp-id

Include port number will cause an error `The relying party ID is not a registrable domain suffix of, nor equal to the current domain.`