### PR TITLE
feat: update guzzlehttp/psr7 requirement to || ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/psr7": "^1.5 || ^2.0 || ^2.1",
+        "guzzlehttp/psr7": "^1.5 || ^2.0",
         "laravel/framework": "^5.8 || ^6.0 || ^7.0 || ^8.0",
         "php-http/discovery": "^1.6",
         "php-http/httplug": "^1.0 || ^2.0",


### PR DESCRIPTION
Fix from #342 which has not been released yet.