### PR TITLE
docs: Add section to v2 upgrade guide

### DIFF
--- a/docs/migration-v1-to-v2.md
+++ b/docs/migration-v1-to-v2.md
@@ -70,7 +70,7 @@ Note that redirects are not used in case of application/json requests.
     - hasKey(\Illuminate\Contracts\Auth\Authenticatable $user)
 
 
-### Existing Keys
+### Keeping Existing Keys
 
 If your application has users with existing Webauthn Keys then you will need to update the encoding of the `credentialId` column in the `webauthn_keys` table from base64 to base64URL, otherwise their key will not be found when they attempt to authenticate. This is because the casting has been updated for the `WebauthnKey` model.
 


### PR DESCRIPTION
Add a section about the change in credentialId encoding for those who have users with existing keys.