### PR TITLE
Fix missing name variable on key registration

### DIFF
--- a/src/Http/Responses/RegisterViewResponse.php
+++ b/src/Http/Responses/RegisterViewResponse.php
@@ -35,8 +35,8 @@ class RegisterViewResponse implements RegisterViewResponseContract
         $view = $this->config->get('webauthn.views.register', '');
 
         return $request->wantsJson()
-            ? Response::json(['publicKey' => $publicKey])
-            : Response::view($view, ['publicKey' => $publicKey]);
+            ? Response::json(['publicKey' => $publicKey, 'name'=>$request->input('name','key')])
+            : Response::view($view, ['publicKey' => $publicKey, 'name'=>$request->input('name','key')]);
     }
 
     /**


### PR DESCRIPTION
During rewrites between 0.8.0 and 2.0.1, the $name GET variable was dropped.