### PR TITLE
fix: fix credentialId migration type

### DIFF
--- a/database/migrations/2019_03_29_163611_add_webauthn.php
+++ b/database/migrations/2019_03_29_163611_add_webauthn.php
@@ -18,7 +18,7 @@ class AddWebauthn extends Migration
             $table->bigInteger('user_id')->unsigned();
 
             $table->string('name')->default('key');
-            $table->string('credentialId', 255);
+            $table->mediumText('credentialId');
             $table->string('type', 255);
             $table->text('transports');
             $table->string('attestationType', 255);


### PR DESCRIPTION
Changed `credentialId` migration type to `mediumText`.

If you already have created the `webauthn_keys` you can upgrade the column with a new migration:
```php
        Schema::table('webauthn_keys', function (Blueprint $table) {
            $table->mediumText('credentialId')->change();
        });
```