### PR TITLE
Refactor CredentialRepository to interface

### DIFF
--- a/src/Contracts/CredentialRepository.php
+++ b/src/Contracts/CredentialRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace LaravelWebauthn\Contracts;
+
+use Illuminate\Contracts\Auth\Authenticatable as User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialSource;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+interface CredentialRepository
+{
+    /**
+     * Return a PublicKeyCredentialSource object.
+     *
+     * @param  string  $publicKeyCredentialId
+     * @return null|PublicKeyCredentialSource
+     */
+    public function findOneByCredentialId(string $publicKeyCredentialId): ?PublicKeyCredentialSource;
+
+    /**
+     * Return a list of PublicKeyCredentialSource objects.
+     *
+     * @param  PublicKeyCredentialUserEntity  $publicKeyCredentialUserEntity
+     * @return PublicKeyCredentialSource[]
+     */
+    public function findAllForUserEntity(PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity): array;
+
+    /**
+     * Save a PublicKeyCredentialSource object.
+     *
+     * @param  PublicKeyCredentialSource  $publicKeyCredentialSource
+     *
+     * @throws ModelNotFoundException
+     */
+    public function saveCredentialSource(PublicKeyCredentialSource $publicKeyCredentialSource): void;
+
+    /**
+     * List of registered PublicKeyCredentialDescriptor associated to the user.
+     *
+     * @param  User  $user
+     * @return PublicKeyCredentialDescriptor[]
+     */
+    public function getRegisteredKeys(User $user);
+}

--- a/src/Services/Webauthn/OptionsFactory.php
+++ b/src/Services/Webauthn/OptionsFactory.php
@@ -5,6 +5,7 @@ namespace LaravelWebauthn\Services\Webauthn;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Http\Request;
+use LaravelWebauthn\Contracts\CredentialRepository;
 use Webauthn\PublicKeyCredentialSourceRepository;
 
 abstract class OptionsFactory extends CredentialValidator


### PR DESCRIPTION
I've been trying to include just the service components of this package (excluding routers, controllers etc) however ran into an issue.

Our repository structure is a little different from the default in this package. It can't be overridden as the underlying `OptionsFactory` doesn't allow for this as it's explicitly typed preventing us from doing so:

https://github.com/asbiin/laravel-webauthn/blob/6aea042122139875404e62b1299c973f5ea346cf/src/Services/Webauthn/OptionsFactory.php#L12-L17

And also doesn't the repository if it's not the required type:

https://github.com/asbiin/laravel-webauthn/blob/6aea042122139875404e62b1299c973f5ea346cf/src/Services/Webauthn/OptionsFactory.php#L37-L39

This PR creates an interface for CredentialRepository and then updates OptionsFactory to use the interface instead.