### PR TITLE
fix: Define index prefix length for MySQL

### DIFF
--- a/database/migrations/2019_03_29_163611_add_webauthn.php
+++ b/database/migrations/2019_03_29_163611_add_webauthn.php
@@ -1,10 +1,10 @@
 <?php
 
+use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\ConnectionResolverInterface as Resolver;
-use Illuminate\Database\MySqlConnection;
 
 class AddWebauthn extends Migration
 {

--- a/database/migrations/2019_03_29_163611_add_webauthn.php
+++ b/database/migrations/2019_03_29_163611_add_webauthn.php
@@ -33,7 +33,7 @@ class AddWebauthn extends Migration
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
 
             if (app(Resolver::class)->connection($this->getConnection()) instanceof MySqlConnection) {
-                $table->rawIndex(app('db')->raw('credentialId(255)'), 'webauthn_keys_credentialid_index');
+                $table->index([app('db')->raw('credentialId(255)')], 'credential_index');
             } else {
                 $table->index('credentialId');
             }

--- a/database/migrations/2019_03_29_163611_add_webauthn.php
+++ b/database/migrations/2019_03_29_163611_add_webauthn.php
@@ -3,6 +3,8 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\MySqlConnection;
 
 class AddWebauthn extends Migration
 {
@@ -29,7 +31,12 @@ class AddWebauthn extends Migration
             $table->timestamps();
 
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
-            $table->index('credentialId');
+
+            if (app(Resolver::class)->connection($this->getConnection()) instanceof MySqlConnection) {
+                $table->rawIndex(app('db')->raw('credentialId(255)'), 'webauthn_keys_credentialid_index');
+            } else {
+                $table->index('credentialId');
+            }
         });
     }
 


### PR DESCRIPTION
I ran into the issue described in #426 while setting up this package on a new project, MySQL requires a key length for the index prefix when creating an index on a text column. This issue would have been introduced in #396 when switching the credentialId column from a varchar to mediumtext.

I'm not sure if additional work would be needed for other database drivers, it seems like defining index prefix lengths in ways compatible with the different grammars has come up for discussion before but was dropped: https://github.com/laravel/framework/issues/9293#issuecomment-578413867.

Please let me know if there's anything else that should be added to this PR.