### PR TITLE
Fix missing french translations

### DIFF
--- a/resources/lang/fr/errors.php
+++ b/resources/lang/fr/errors.php
@@ -1,10 +1,12 @@
 <?php
 
 return [
+    'login_failed' => 'Echec de l\'authentification',
     'user_unauthenticated' => 'Vous devez vous connecter avant de faire une authentification Webauthn',
     'auth_data_not_found' => 'Données d’authentification introuvables',
-    'create_data_not_found' => 'Données d’enregistrement non trouvées',
+    'create_data_not_found' => 'Données d’enregistrement introuvables',
     'cannot_register_new_key' => 'Vous devez vous connecter avant de pouvoir ajouter une nouvelle authentification Webauthn',
+    'wrong_validation' => 'Erreur lors de la validation de la clé',
     'object_not_found' => 'Objet introuvable',
 
     'not_supported' => 'Votre navigateur ne prend actuellement pas en charge WebAuthn.',

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -2,10 +2,12 @@
 
 return [
     'buttonAdvise' => 'Si votre clé de sécurité dispose d’un bouton, appuyez dessus.',
-    'noButtonAdvise' => 'Si ce n’est pas le cas, enlevez-la et insérez là à nouveau.',
+    'noButtonAdvise' => 'Si ce n’est pas le cas, enlevez-la et insérez la à nouveau.',
     'success' => 'Votre clé est détectée et validée.',
     'insertKey' => 'Insérer votre clé de sécurité',
     'cancel' => 'Annuler',
+    'submit' => 'Envoyer',
+    'key_name' => 'Nom de la clé',
 
     'auth' => [
         'title' => 'Authentification avec une clé de sécurité',


### PR DESCRIPTION
Hi,
Some french translations were missing in languages files. I suggest this PR to fix that.
Note that I'm french, so translations in this language are simple to do for me. Don't hesitate to ask if you have some questions.

Summary :
* Adding login_failed, and wrong_validation in errors.php
* Adding submit and key_name in messages.php
* Updating create_data_not_found in errors.php to use the word "introuvables" (not found, plural form), to use the same form everywhere (it was the only place where you didn't use this word, others already uses it).

Note that I used the verb "Envoyer" for the submit key, which is the litteral translation for "Submit", but I recommend to use a less generic verb, like "continue" or "validate".

Thanks for this excellent package, this is really good work.
Have a nice day