### PR TITLE
fix: conflict with web-auth/webauthn-lib:4.7.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: SonarCloud Scan
         if: env.SONAR_TOKEN != ''
-        uses: SonarSource/sonarcloud-github-action@v1.9
+        uses: SonarSource/sonarcloud-github-action@v2.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,12 @@
         "psr/http-factory-implementation": "1.0",
         "thecodingmachine/safe": "^2.0",
         "web-auth/cose-lib": "^4.0",
+        "web-auth/metadata-service": "^4.0",
         "web-auth/webauthn-lib": "^4.0",
         "web-token/jwt-signature": "^3.0"
+    },
+    "conflict": {
+        "web-auth/webauthn-lib": "4.7.0"
     },
     "require-dev": {
         "ext-sqlite3": "*",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "illuminate/support": "^9.0 || ^10.0",
         "psr/http-factory-implementation": "1.0",
         "web-auth/cose-lib": "^4.0",
-        "web-auth/metadata-service": "^4.0",
         "web-auth/webauthn-lib": "^4.0",
         "web-token/jwt-signature": "^3.0"
     },

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -2,11 +2,14 @@
 
 namespace LaravelWebauthn\Tests\Unit\Models;
 
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use LaravelWebauthn\Models\WebauthnKey;
 use LaravelWebauthn\Tests\FeatureTestCase;
 
 class UserTest extends FeatureTestCase
 {
+    use DatabaseTransactions;
+
     /**
      * @test
      */


### PR DESCRIPTION
web-auth/webauthn-lib:4.7.0 generates an `JsonException: Malformed UTF-8 characters` error.

Also remove inconsistent test.