### PR TITLE
fix: fix timeout and cache behavior

### DIFF
--- a/config/webauthn.php
+++ b/config/webauthn.php
@@ -173,10 +173,11 @@ return [
     |--------------------------------------------------------------------------
     |
     | Time that the caller is willing to wait for the call to complete.
+    | See https://webauthn-doc.spomky-labs.com/symfony-bundle/configuration-references#timeout
     |
     */
 
-    'timeout' => 60000,
+    'timeout' => null,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Services/JsonWrapper.php
+++ b/src/Services/JsonWrapper.php
@@ -18,7 +18,6 @@ class JsonWrapper implements JsonSerializable
      * @param  T  $data
      */
     public function __construct(
-        private SerializerInterface $loader,
         public mixed $data
     ) {}
 
@@ -37,7 +36,7 @@ class JsonWrapper implements JsonSerializable
     #[\Override]
     public function __toString()
     {
-        return $this->loader->serialize($this->data, 'json', [
+        return app(SerializerInterface::class)->serialize($this->data, 'json', [
             AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
             JsonEncode::OPTIONS => JSON_THROW_ON_ERROR,
         ]);

--- a/src/Services/Webauthn/CreationOptionsFactory.php
+++ b/src/Services/Webauthn/CreationOptionsFactory.php
@@ -10,7 +10,6 @@ use Illuminate\Http\Request;
 use LaravelWebauthn\Facades\Webauthn;
 use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\PublicKeyCredentialCreationOptions as PublicKeyCredentialCreationOptionsBase;
-use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialParameters;
 use Webauthn\PublicKeyCredentialRpEntity;
 use Webauthn\PublicKeyCredentialUserEntity;
@@ -51,7 +50,7 @@ final class CreationOptionsFactory extends OptionsFactory
         );
 
         return tap(PublicKeyCredentialCreationOptions::create($publicKey), function (PublicKeyCredentialCreationOptions $result) use ($user): void {
-            $this->cache->put($this->cacheKey($user), (string) $result, $this->timeout);
+            $this->cache->put($this->cacheKey($user), (string) $result, $this->timeoutCache);
         });
     }
 
@@ -74,10 +73,7 @@ final class CreationOptionsFactory extends OptionsFactory
     private function createCredentialParameters(): array
     {
         return collect($this->algorithmManager->list())
-            ->map(fn ($algorithm): PublicKeyCredentialParameters => new PublicKeyCredentialParameters(
-                PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
-                $algorithm
-            ))
+            ->map(fn (int $algorithm): PublicKeyCredentialParameters => PublicKeyCredentialParameters::createPk($algorithm))
             ->toArray();
     }
 

--- a/src/Services/Webauthn/CredentialAssertionValidator.php
+++ b/src/Services/Webauthn/CredentialAssertionValidator.php
@@ -60,6 +60,10 @@ class CredentialAssertionValidator extends CredentialValidator
                 $value = $this->cache->pull($this->cacheKey(null));
             }
 
+            if ($value === null) {
+                abort(404, 'No public key credential found');
+            }
+
             return $this->loader->deserialize($value, PublicKeyCredentialRequestOptions::class, 'json');
         } catch (\Exception $e) {
             app('webauthn.log')->debug('Webauthn publickKey deserialize error', ['exception' => $e]);

--- a/src/Services/Webauthn/CredentialAssertionValidator.php
+++ b/src/Services/Webauthn/CredentialAssertionValidator.php
@@ -67,7 +67,7 @@ class CredentialAssertionValidator extends CredentialValidator
             return $this->loader->deserialize($value, PublicKeyCredentialRequestOptions::class, 'json');
         } catch (\Exception $e) {
             app('webauthn.log')->debug('Webauthn publickKey deserialize error', ['exception' => $e]);
-            abort(404);
+            abort(404, $e->getMessage());
         }
     }
 

--- a/src/Services/Webauthn/CredentialAssertionValidator.php
+++ b/src/Services/Webauthn/CredentialAssertionValidator.php
@@ -42,7 +42,7 @@ class CredentialAssertionValidator extends CredentialValidator
             $this->getResponse($publicKeyCredential),
             $this->pullPublicKey($user),
             $this->request->host(),
-            $user->getAuthIdentifier()
+            optional($user)->getAuthIdentifier()
         );
 
         return true;

--- a/src/Services/Webauthn/CredentialAttestationValidator.php
+++ b/src/Services/Webauthn/CredentialAttestationValidator.php
@@ -51,6 +51,10 @@ class CredentialAttestationValidator extends CredentialValidator
         try {
             $value = $this->cache->pull($this->cacheKey($user));
 
+            if ($value === null) {
+                abort(404, 'No public key credential found');
+            }
+
             return $this->loader->deserialize($value, PublicKeyCredentialCreationOptions::class, 'json');
         } catch (\Exception $e) {
             app('webauthn.log')->debug('Webauthn publicKey deserialize error', ['exception' => $e]);

--- a/src/Services/Webauthn/CredentialAttestationValidator.php
+++ b/src/Services/Webauthn/CredentialAttestationValidator.php
@@ -58,7 +58,7 @@ class CredentialAttestationValidator extends CredentialValidator
             return $this->loader->deserialize($value, PublicKeyCredentialCreationOptions::class, 'json');
         } catch (\Exception $e) {
             app('webauthn.log')->debug('Webauthn publicKey deserialize error', ['exception' => $e]);
-            abort(404);
+            abort(404, $e->getMessage());
         }
     }
 

--- a/src/Services/Webauthn/OptionsFactory.php
+++ b/src/Services/Webauthn/OptionsFactory.php
@@ -55,7 +55,7 @@ abstract class OptionsFactory extends CredentialValidator
      */
     private static function getDefaultTimeoutCache(Config $config): ?int
     {
-        switch ($config->get('webauthn.user_verification', 'preferred')) {
+        switch ($config->get('webauthn.user_verification')) {
             case 'discouraged':
                 return 180;
             case 'preferred':

--- a/src/Services/Webauthn/OptionsFactory.php
+++ b/src/Services/Webauthn/OptionsFactory.php
@@ -36,7 +36,7 @@ abstract class OptionsFactory extends CredentialValidator
             $this->timeout = (int) $timeout;
             $this->timeoutCache = $this->timeout / 1000;
         } else {
-            $this->timeoutCache = static::getDefaultTimeoutCache($config);
+            $this->timeoutCache = self::getDefaultTimeoutCache($config);
         }
     }
 
@@ -61,8 +61,8 @@ abstract class OptionsFactory extends CredentialValidator
             case 'preferred':
             case 'required':
                 return 600;
+            default:
+                return null;
         }
-
-        return null;
     }
 }

--- a/src/Services/Webauthn/OptionsFactory.php
+++ b/src/Services/Webauthn/OptionsFactory.php
@@ -55,7 +55,7 @@ abstract class OptionsFactory extends CredentialValidator
      */
     private static function getDefaultTimeoutCache(Config $config): ?int
     {
-        switch ($config->get('webauthn.user_verification')) {
+        switch ($config->get('webauthn.user_verification', 'preferred')) {
             case 'discouraged':
                 return 180;
             case 'preferred':

--- a/src/Services/Webauthn/OptionsFactory.php
+++ b/src/Services/Webauthn/OptionsFactory.php
@@ -16,7 +16,12 @@ abstract class OptionsFactory extends CredentialValidator
     /**
      * Timeout in milliseconds.
      */
-    protected int $timeout;
+    protected ?int $timeout = null;
+
+    /**
+     * Timeout in milliseconds.
+     */
+    protected ?int $timeoutCache;
 
     public function __construct(
         Request $request,
@@ -26,7 +31,13 @@ abstract class OptionsFactory extends CredentialValidator
         parent::__construct($request, $cache);
 
         $this->challengeLength = (int) $config->get('webauthn.challenge_length', 32);
-        $this->timeout = (int) $config->get('webauthn.timeout', 60000);
+        $timeout = $config->get('webauthn.timeout');
+        if ($timeout !== null) {
+            $this->timeout = (int) $timeout;
+            $this->timeoutCache = $this->timeout / 1000;
+        } else {
+            $this->timeoutCache = static::getDefaultTimeoutCache($config);
+        }
     }
 
     /**
@@ -37,5 +48,21 @@ abstract class OptionsFactory extends CredentialValidator
     protected function getChallenge(): string
     {
         return \random_bytes($this->challengeLength);
+    }
+
+    /**
+     * See https://webauthn-doc.spomky-labs.com/symfony-bundle/configuration-references#timeout
+     */
+    private static function getDefaultTimeoutCache(Config $config): ?int
+    {
+        switch ($config->get('webauthn.user_verification', 'preferred')) {
+            case 'discouraged':
+                return 180;
+            case 'preferred':
+            case 'required':
+                return 600;
+        }
+
+        return null;
     }
 }

--- a/src/Services/Webauthn/RequestOptionsFactory.php
+++ b/src/Services/Webauthn/RequestOptionsFactory.php
@@ -41,7 +41,7 @@ final class RequestOptionsFactory extends OptionsFactory
         );
 
         return tap(PublicKeyCredentialRequestOptions::create($publicKey), function (PublicKeyCredentialRequestOptions $result) use ($user): void {
-            $this->cache->put($this->cacheKey($user), (string) $result, $this->timeout);
+            $this->cache->put($this->cacheKey($user), (string) $result, $this->timeoutCache);
         });
     }
 

--- a/tests/Unit/Services/Webauthn/CreationOptionsFactoryTest.php
+++ b/tests/Unit/Services/Webauthn/CreationOptionsFactoryTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace LaravelWebauthn\Tests\Unit\Services\Webauthn;
+
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use LaravelWebauthn\Services\Webauthn\RequestOptionsFactory;
+use LaravelWebauthn\Tests\FeatureTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Webauthn\PublicKeyCredentialRequestOptions;
+
+class CreationOptionsFactoryTest extends FeatureTestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function create_options_factory()
+    {
+        $user = $this->user();
+
+        $option = app(RequestOptionsFactory::class)($user);
+
+        $this->assertInstanceOf(PublicKeyCredentialRequestOptions::class, $option->data);
+        $this->assertNotNull($option->data->challenge);
+        $this->assertEquals(32, strlen($option->data->challenge));
+        $this->assertNull($option->data->timeout);
+    }
+
+    #[Test]
+    public function create_options_factory_timeout()
+    {
+        config(['webauthn.timeout' => 300000]);
+
+        $user = $this->user();
+
+        $this->mock(Cache::class, function ($mock) {
+            $mock->shouldReceive('put')
+                ->withArgs(function ($key, $value, $timeout) {
+                    $this->assertEquals(300, $timeout);
+
+                    return true;
+                })
+                ->andReturnTrue();
+        });
+
+        $option = app(RequestOptionsFactory::class)($user);
+
+        $this->assertInstanceOf(PublicKeyCredentialRequestOptions::class, $option->data);
+        $this->assertNotNull($option->data->challenge);
+        $this->assertEquals(32, strlen($option->data->challenge));
+        $this->assertEquals(300000, $option->data->timeout);
+    }
+
+    #[Test]
+    public function create_options_factory_discouraged()
+    {
+        config(['webauthn.user_verification' => 'discouraged']);
+
+        $user = $this->user();
+
+        $this->mock(Cache::class, function ($mock) {
+            $mock->shouldReceive('put')
+                ->withArgs(function ($key, $value, $timeout) {
+                    $this->assertEquals(180, $timeout);
+
+                    return true;
+                })
+                ->andReturnTrue();
+        });
+
+        $option = app(RequestOptionsFactory::class)($user);
+
+        $this->assertInstanceOf(PublicKeyCredentialRequestOptions::class, $option->data);
+        $this->assertNotNull($option->data->challenge);
+        $this->assertEquals(32, strlen($option->data->challenge));
+        $this->assertNull($option->data->timeout);
+    }
+
+    #[Test]
+    public function create_options_factory_required()
+    {
+        config(['webauthn.user_verification' => 'required']);
+
+        $user = $this->user();
+
+        $this->mock(Cache::class, function ($mock) {
+            $mock->shouldReceive('put')
+                ->withArgs(function ($key, $value, $timeout) {
+                    $this->assertEquals(600, $timeout);
+
+                    return true;
+                })
+                ->andReturnTrue();
+        });
+
+        $option = app(RequestOptionsFactory::class)($user);
+
+        $this->assertInstanceOf(PublicKeyCredentialRequestOptions::class, $option->data);
+        $this->assertNotNull($option->data->challenge);
+        $this->assertEquals(32, strlen($option->data->challenge));
+        $this->assertNull($option->data->timeout);
+    }
+
+    #[Test]
+    public function create_options_factory_preferred()
+    {
+        config(['webauthn.user_verification' => 'preferred']);
+
+        $user = $this->user();
+
+        $this->mock(Cache::class, function ($mock) {
+            $mock->shouldReceive('put')
+                ->withArgs(function ($key, $value, $timeout) {
+                    $this->assertEquals(600, $timeout);
+
+                    return true;
+                })
+                ->andReturnTrue();
+        });
+
+        $option = app(RequestOptionsFactory::class)($user);
+
+        $this->assertInstanceOf(PublicKeyCredentialRequestOptions::class, $option->data);
+        $this->assertNotNull($option->data->challenge);
+        $this->assertEquals(32, strlen($option->data->challenge));
+        $this->assertNull($option->data->timeout);
+    }
+}

--- a/tests/Unit/Services/Webauthn/CredentialAssertionValidatorTest.php
+++ b/tests/Unit/Services/Webauthn/CredentialAssertionValidatorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace LaravelWebauthn\Tests\Unit\Services\Webauthn;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\Request;
+use Jose\Component\Core\Util\Base64UrlSafe;
+use LaravelWebauthn\Models\WebauthnKey;
+use LaravelWebauthn\Services\Webauthn\CredentialAssertionValidator;
+use LaravelWebauthn\Services\Webauthn\RequestOptionsFactory;
+use LaravelWebauthn\Tests\FeatureTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Serializer\SerializerInterface;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\AuthenticatorData;
+use Webauthn\CollectedClientData;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\TrustPath\EmptyTrustPath;
+use Webauthn\TrustPath\TrustPath;
+
+class CredentialAssertionValidatorTest extends FeatureTestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function create_credential_assertion_validator()
+    {
+        $user = $this->user();
+        $webauthnKey = factory(WebauthnKey::class)->create([
+            'user_id' => $user->getAuthIdentifier(),
+        ]);
+
+        $this->mock(Request::class, function ($mock) {
+            $mock->shouldReceive('host')
+                ->andReturn('localhost');
+            $mock->shouldReceive('ip')
+                ->andReturn('127.0.0.1');
+        });
+
+        $option = app(RequestOptionsFactory::class)($user);
+
+        $this->mock(SerializerInterface::class, function ($mock) use ($webauthnKey, $option) {
+            $mock->shouldReceive('deserialize')
+                ->withSomeOfArgs(TrustPath::class)
+                ->andReturn(new EmptyTrustPath);
+            $mock->shouldReceive('deserialize')
+                ->withSomeOfArgs(PublicKeyCredential::class)
+                ->andReturn(new PublicKeyCredential('public-key', $webauthnKey->credentialId, new AuthenticatorAssertionResponse(
+                    $this->mock(CollectedClientData::class),
+                    $this->mock(AuthenticatorData::class),
+                    'signature',
+                    'userHandle'
+                )));
+            $mock->shouldReceive('deserialize')
+                ->withSomeOfArgs(PublicKeyCredentialRequestOptions::class)
+                ->andReturn($option->data);
+            $mock->shouldReceive('serialize')
+                ->andReturn('{"challenge":"KTWMgB3ND1SbaoM8xEBZvbR1Y5Ehm5gC5p2t73Nd15g","rpId":"localhost","allowCredentials":[{"type":"public-key","id":"TVE"}],"userVerification":"preferred"}');
+        });
+        $this->mock(AuthenticatorAssertionResponseValidator::class, function ($mock) {
+            $mock->shouldReceive('check');
+        });
+
+        $creds = new PublicKeyCredential('public-key', $webauthnKey->credentialId, new AuthenticatorAssertionResponse(
+            $this->mock(CollectedClientData::class),
+            $this->mock(AuthenticatorData::class),
+            'signature',
+            'userHandle'
+        ));
+        $data = json_decode(json_encode($creds), true);
+        $data['id'] = Base64UrlSafe::encodeUnpadded($webauthnKey->credentialId);
+        $data['rawId'] = base64_encode($webauthnKey->credentialId);
+
+        $test = app(CredentialAssertionValidator::class);
+        $result = $test($user, $data);
+
+        $this->assertTrue($result);
+    }
+}

--- a/tests/Unit/Services/Webauthn/CredentialAttestationValidatorTest.php
+++ b/tests/Unit/Services/Webauthn/CredentialAttestationValidatorTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace LaravelWebauthn\Tests\Unit\Services\Webauthn;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use LaravelWebauthn\Services\Webauthn\CreationOptionsFactory;
+use LaravelWebauthn\Services\Webauthn\CredentialAttestationValidator;
+use LaravelWebauthn\Tests\FeatureTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Serializer\SerializerInterface;
+use Webauthn\AttestationStatement\AttestationObject;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\CollectedClientData;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialSource;
+use Webauthn\TrustPath\EmptyTrustPath;
+use Webauthn\TrustPath\TrustPath;
+
+class CredentialAttestationValidatorTest extends FeatureTestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function create_credential_attestation_validator()
+    {
+        $user = $this->user();
+
+        $option = app(CreationOptionsFactory::class)($user);
+        $creds = new PublicKeyCredential('public-key', 'id', new AuthenticatorAttestationResponse(
+            $this->mock(CollectedClientData::class),
+            $this->mock(AttestationObject::class)
+        ));
+        $response = $this->mock(PublicKeyCredentialSource::class);
+
+        $this->mock(SerializerInterface::class, function ($mock) use ($option, $creds) {
+            $mock->shouldReceive('deserialize')
+                ->withSomeOfArgs(TrustPath::class)
+                ->andReturn(new EmptyTrustPath);
+            $mock->shouldReceive('deserialize')
+                ->withSomeOfArgs(PublicKeyCredential::class)
+                ->andReturn($creds);
+            $mock->shouldReceive('deserialize')
+                ->withSomeOfArgs(PublicKeyCredentialCreationOptions::class)
+                ->andReturn($option->data);
+        });
+        $this->mock(AuthenticatorAttestationResponseValidator::class, function ($mock) use ($response) {
+            $mock->shouldReceive('check')
+                ->andReturn($response);
+        });
+
+        $data = json_decode(json_encode($creds), true);
+        $test = app(CredentialAttestationValidator::class);
+        $result = $test($user, $data);
+
+        $this->assertEquals($response, $result);
+    }
+
+    #[Test]
+    public function create_credential_attestation_validator_and_fail()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No public key credential found');
+
+        $user = $this->user();
+
+        $creds = new PublicKeyCredential('public-key', 'id', new AuthenticatorAttestationResponse(
+            $this->mock(CollectedClientData::class),
+            $this->mock(AttestationObject::class)
+        ));
+
+        $this->mock(SerializerInterface::class, function ($mock) use ($creds) {
+            $mock->shouldReceive('deserialize')
+                ->withSomeOfArgs(TrustPath::class)
+                ->andReturn(new EmptyTrustPath);
+            $mock->shouldReceive('deserialize')
+                ->withSomeOfArgs(PublicKeyCredential::class)
+                ->andReturn($creds);
+        });
+
+        $data = json_decode(json_encode($creds), true);
+        $test = app(CredentialAttestationValidator::class);
+        $test($user, $data);
+
+        $this->fail('No exception thrown');
+    }
+}

--- a/tests/Unit/Services/WebauthnTest.php
+++ b/tests/Unit/Services/WebauthnTest.php
@@ -77,6 +77,8 @@ class WebauthnTest extends FeatureTestCase
      */
     public function test_get_authenticate_data()
     {
+        config(['webauthn.timeout' => 60000]);
+
         $user = $this->signIn();
         factory(WebauthnKey::class)->create([
             'user_id' => $user->getAuthIdentifier(),


### PR DESCRIPTION
As explain on 
> The [default] timeout is set to null. The values recommended by the specification are as follow:
>
>    If the user verification is discouraged, timeout should be between 30 and 180 seconds
>
>    If the user verification is preferred or required, the range is 300 to 600 seconds (5 to 10 minutes)
>
> These behaviors are not necessarily followed by the web browsers.

The Laravel cache `put` operation now converts the timeout from milliseconds to seconds.
If the timeout is null, then the maximum default recommendation is used for the cache operation.

Fix #496 