### PR TITLE
fix: Remove deprecated RS1 algorithm from list for factory

### DIFF
--- a/src/WebauthnServiceProvider.php
+++ b/src/WebauthnServiceProvider.php
@@ -229,7 +229,6 @@ class WebauthnServiceProvider extends ServiceProvider
             fn () => tap(new CoseAlgorithmManagerFactory, function ($factory) {
                 // list of existing algorithms
                 $algorithms = [
-                    RSA\RS1::class,
                     RSA\RS256::class,
                     RSA\RS384::class,
                     RSA\RS512::class,


### PR DESCRIPTION
This addresses https://github.com/asbiin/laravel-webauthn/issues/530. Normally I'd make this a configurable value, but this algorithm has been [recommended to not be used for a long time](https://github.com/web-auth/cose-lib/issues/152), so it's probably best to remove it completely.